### PR TITLE
Move vendors to non-shared folder

### DIFF
--- a/app/autoload.php
+++ b/app/autoload.php
@@ -6,7 +6,7 @@ use Composer\Autoload\ClassLoader;
 /**
  * @var ClassLoader $loader
  */
-$loader = require __DIR__.'/../vendor/autoload.php';
+$loader = require '/dev/shm/symfony_docker_test/vendor/autoload.php';
 
 AnnotationRegistry::registerLoader([$loader, 'loadClass']);
 

--- a/composer.json
+++ b/composer.json
@@ -60,5 +60,8 @@
         "incenteev-parameters": {
             "file": "app/config/parameters.yml"
         }
+    },
+    "config": {
+        "vendor-dir": "/dev/shm/symfony_docker_test/vendor"
     }
 }


### PR DESCRIPTION
This really enhances performance with Docker for Mac (and probably Vagrant with NFS share too)
