### PR TITLE
User proper syntax for AB on MacOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ You can switch to the `non-shared-vendor` branch to make tests with `cache`, `lo
 Benchmarks results from this command in Symfony `prod` environment:
 
     ab -n 100 -r 127.0.0.1:8080
-    OR
+ 
+ or:
+ 
     ab -n 100 -r http://127.0.0.1:8080/
 
 |                                                         | Docker 1.11.1-beta11 | Docker 1.11.1-beta13 |

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ You can switch to the `non-shared-vendor` branch to make tests with `cache`, `lo
 Benchmarks results from this command in Symfony `prod` environment:
 
     ab -n 100 -r 127.0.0.1:8080
+    OR
+    ab -n 100 -r http://127.0.0.1:8080/
 
 |                                                         | Docker 1.11.1-beta11 | Docker 1.11.1-beta13 |
 |---------------------------------------------------------|----------------------|----------------------|


### PR DESCRIPTION
Since

`ab -n 100 -r 127.0.0.1:8080` results in `ab: invalid URL`
